### PR TITLE
Fix exporting drill-down dimensions

### DIFF
--- a/GINQO_MasterItemManager.js
+++ b/GINQO_MasterItemManager.js
@@ -403,7 +403,7 @@ return {
 
 										item.map(item => {
 											itemsFormatted.push({
-												Field: `"${item.qDim.qFieldDefs[0]}"`, // remove commas to avoid errors,
+												Field: `"${item.qDim.qFieldDefs.join(', ')}"`,
 												Name: `"${item.qDim.title}"`,
 												LabelExpression: `"${item.qDim.qLabelExpression}"`.replace("undefined", ""),
 												Description: `"${item.qMetaDef.description}"`,


### PR DESCRIPTION
Exporting dimensions currently just outputs the first field in the list and ignores the rest.  Instead, I changed it to join the fields with commas and spaces, like this:

['Year', 'Month', 'Day'] -> 'Year, Month, Day'