### PR TITLE
Fix importing expression-based dimensions

### DIFF
--- a/GINQO_MasterItemManager.js
+++ b/GINQO_MasterItemManager.js
@@ -135,9 +135,17 @@ return {
 														if (!arrayDimensions.includes(row.cells[6].qText)) {
 
 															console.log(row);
-															var dimensionfields = row.cells[1].qText.split(",").map(item => {
-																return item.trim();
-															})
+
+															var qText = row.cells[1].qText;
+															var dimensionfields;
+															if (qText.startsWith('='))  // expression
+																dimensionfields = [qText.trim()];
+															else {  // single field or drill-down field list
+																dimensionfields = qText.split(",").map(item => {
+																	return item.trim();
+																});
+															}
+
 															var labelExpression = row.cells[2].qText;
 															//var description = row.cells[3].qText;
 															var description;
@@ -223,9 +231,17 @@ return {
 																		return item.trim(); // Return item with no whitespace
 																	});
 																	tags.push('Master Item Manager');
-																	var dimensionfields = row.cells[1].qText.split(",").map(item => {
-																		return item.trim();
-																	})
+
+																	var qText = row.cells[1].qText;
+																	var dimensionfields;
+																	if (qText.startsWith('='))  // expression
+																		dimensionfields = [qText.trim()];
+																	else {  // single field or drill-down field list
+																		dimensionfields = qText.split(",").map(item => {
+																			return item.trim();
+																		});
+																	}
+
 																	var qGrouping;
 
 																	if (dimensionfields.length > 1) {


### PR DESCRIPTION
Currently, when dimensions are imported, it's assumed that if there is a comma in the field, it's because it's a drill-down dimension.  But dimensions can be expressions and expressions can contain commas.  I updated the code so that if the first character of the dimension is '=', the expression is left alone instead of getting split at each comma.