### PR TITLE
Update GINQO_MasterItemManager.js

### DIFF
--- a/GINQO_MasterItemManager.js
+++ b/GINQO_MasterItemManager.js
@@ -709,7 +709,10 @@ function ($, qlik, mainModalWindow, helpModalWindow, dimModalWindow, dimModalCon
                     //console.log(tagsList);
                     tagsList = tagsList.filter(a => a !== '-');
                 }
+		// 2022-11-04 (goos-it) check if tag 'Master Item Manager' exists before pushing it to the array (to prevent duplicates on export/import cycle)
+             	if	(!tagsList.includes('Master Item Manager')) {					
                 tagsList.push('Master Item Manager')
+                }
     
             
                 // 2020-09-09 (Riki) Filter and parse SEGMENTCOLOR

--- a/GINQO_MasterItemManager.js
+++ b/GINQO_MasterItemManager.js
@@ -223,7 +223,11 @@ function ($, qlik, mainModalWindow, helpModalWindow, dimModalWindow, dimModalCon
                                                     itemDescription = item.qMeasure.descriptionExpression.qStringExpression.qExpr.replace(/\"/g,'""');
                                                 }
                                                 else{
-                                                    itemDescription = item.qMetaDef.description.replace(/\"/g,'""');
+                                                    	if(item.qMetaDef.description !== undefined){
+                                                    		itemDescription = item.qMetaDef.description.replace(/\"/g,'""');
+							} else {
+								itemDescription = "";
+							}
                                                 }
                                                 
                                                 // 2020-09-23 (Riki) Conditional statement to parse Measure base color


### PR DESCRIPTION
Checking if item.qMetaDef.description is defined in line 226 fixes an error that the export of measures failes without any message. (See my issue #32 )